### PR TITLE
Update CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28)
 project(mrs_uav_hw_api)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -48,30 +48,56 @@ set(DEPENDENCIES
 set(LIBRARIES
   MrsUavHwApi_HwApiManager
   MrsUavHwApi_DummyApi
-  )
+)
 
 foreach(DEP IN LISTS DEPENDENCIES)
   find_package(${DEP} REQUIRED)
 endforeach()
 
-include_directories(
-  include
-  ${rclcpp_INCLUDE_DIRS}
-  ${mrs_lib_INCLUDE_DIRS}
-  ${mrs_uav_testing_INCLUDE_DIRS}
-  )
+add_library(MrsUavHwApi_MrsUavHwApi INTERFACE)
+add_library(mrs_uav_hw_api::mrs_uav_hw_api ALIAS MrsUavHwApi_MrsUavHwApi)
+set_target_properties(MrsUavHwApi_MrsUavHwApi
+  PROPERTIES
+    EXPORT_NAME mrs_uav_hw_api
+    OUTPUT_NAME mrs_uav_hw_api
+)
+target_sources(MrsUavHwApi_MrsUavHwApi
+  INTERFACE FILE_SET HEADERS BASE_DIRS "include"
+  FILES
+    "include/mrs_uav_hw_api/api.h"
+    "include/mrs_uav_hw_api/common_handlers.h"
+    "include/mrs_uav_hw_api/publishers.h"
+)
+target_link_libraries(MrsUavHwApi_MrsUavHwApi
+  INTERFACE
+    rclcpp::rclcpp
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+)
 
 # Hw API manager
 
 add_library(MrsUavHwApi_HwApiManager SHARED
   src/hw_api_manager.cpp
-  )
-
-ament_target_dependencies(MrsUavHwApi_HwApiManager
-  ${DEPENDENCIES}
 )
 
-rclcpp_components_register_nodes(MrsUavHwApi_HwApiManager PLUGIN "mrs_uav_hw_api::HwApiManager" EXECUTABLE MrsUavHwApi_HwApiManager)
+target_link_libraries(MrsUavHwApi_HwApiManager
+  PRIVATE
+    mrs_uav_hw_api::mrs_uav_hw_api
+    rclcpp::rclcpp
+    rclcpp_components::component
+    pluginlib::pluginlib
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+)
+
+rclcpp_components_register_nodes(MrsUavHwApi_HwApiManager "mrs_uav_hw_api::HwApiManager")
 
 target_compile_definitions(MrsUavHwApi_HwApiManager PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
 
@@ -79,10 +105,19 @@ target_compile_definitions(MrsUavHwApi_HwApiManager PRIVATE USE_ROS_TIMER=${USE_
 
 add_library(MrsUavHwApi_DummyApi SHARED
   src/dummy_api.cpp
-  )
+)
 
-ament_target_dependencies(MrsUavHwApi_DummyApi
-  ${DEPENDENCIES}
+target_link_libraries(MrsUavHwApi_DummyApi
+  PRIVATE
+    mrs_uav_hw_api::mrs_uav_hw_api
+    rclcpp::rclcpp
+    rclcpp_components::component
+    pluginlib::pluginlib
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
 )
 
 target_compile_definitions(MrsUavHwApi_DummyApi PRIVATE USE_ROS_TIMER=${USE_ROS_TIMER})
@@ -108,21 +143,15 @@ endif()
 ## |                           Install                          |
 ## --------------------------------------------------------------
 
-ament_export_libraries(
-  ${LIBRARIES}
-)
-
 install(
-  TARGETS ${LIBRARIES}
+  TARGETS
+    MrsUavHwApi_MrsUavHwApi
+    ${LIBRARIES}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  )
-
-install(
-  DIRECTORY include/
-  DESTINATION include
+  FILE_SET HEADERS DESTINATION "include/${PROJECT_NAME}"
 )
 
 install(
@@ -135,12 +164,16 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
-ament_export_include_directories(
-  include
-)
-
 ament_export_targets(
   export_${PROJECT_NAME} HAS_LIBRARY_TARGET
+)
+
+ament_export_include_directories(
+  "include/${PROJECT_NAME}"
+)
+
+ament_export_libraries(
+  ${LIBRARIES}
 )
 
 ament_export_dependencies(

--- a/include/mrs_uav_hw_api/common_handlers.h
+++ b/include/mrs_uav_hw_api/common_handlers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include <mrs_uav_hw_api/publishers.h>
 #include <mrs_lib/transformer.h>
 #include <mrs_lib/param_loader.h>
@@ -47,4 +49,4 @@ struct CommonHandlers_t
   getWorldFrameName_t getWorldFrameName;
 };
 
-}  // namespace mrs_uav_hw_api
+} // namespace mrs_uav_hw_api

--- a/include/mrs_uav_hw_api/publishers.h
+++ b/include/mrs_uav_hw_api/publishers.h
@@ -1,6 +1,8 @@
 #ifndef PUBLISHERS_H
 #define PUBLISHERS_H
 
+#include <functional>
+
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/range.hpp>
@@ -143,6 +145,6 @@ struct Publishers_t
   publishOdometry_t publishGroundTruth;
 };
 
-}  // namespace mrs_uav_hw_api
+} // namespace mrs_uav_hw_api
 
-#endif  // PUBLISHERS_H
+#endif // PUBLISHERS_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,4 +7,4 @@ function(add_ros_isolated_launch_test path)
   add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
 endfunction()
 
-add_subdirectory(./load_dummy)
+add_subdirectory(load_dummy)

--- a/test/load_dummy/CMakeLists.txt
+++ b/test/load_dummy/CMakeLists.txt
@@ -2,23 +2,19 @@ get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
 add_executable(test_${TEST_NAME}
   test.cpp
-  )
-
-ament_target_dependencies(test_${TEST_NAME}
-  rclcpp
-  mrs_lib
-  mrs_msgs
-  backward_ros
-  )
+)
 
 target_link_libraries(test_${TEST_NAME}
-  MrsUavHwApi_HwApiManager
-  MrsUavHwApi_DummyApi
-  )
+  PRIVATE
+    mrs_uav_testing::mrs_uav_testing
+    rclcpp::rclcpp
+    mrs_lib::mrs_lib
+    ${mrs_msgs_TARGETS}
+)
 
-install(TARGETS
-  test_${TEST_NAME}
+install(
+  TARGETS test_${TEST_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 add_ros_isolated_launch_test(test.py TIMEOUT 300)


### PR DESCRIPTION
- increased minimum required version of CMake to 3.28
- added interface target mrs_uav_hw_api::mrs_uav_hw_api
  - users can directly link against this target to use the library
  - projects no longer need to manually include
    mrs_uav_hw_api_INCLUDE_DIRS
  - added explicit headers with cmake file set
- changed install location of headers
  - instead of being directly in the include directory, they are put in
    a subfolder to aid isolation
- removed unnecessary global include_directories
- changed uses of `ament_target_dependencies` to `target_link_libraries`

Additional changes:
- added missing includes