### PR TITLE
Errorgraph integration, publishing of errors

### DIFF
--- a/include/mrs_uav_hw_api/api.h
+++ b/include/mrs_uav_hw_api/api.h
@@ -39,7 +39,7 @@ public:
    * @param node Node handle - Use this to create subscibers, publisher, etc.
    * @param common_handlers Structure pre-filled with useful variables, methods and objects that the plugin can use.
    */
-  virtual void initialize(const rclcpp::Node::SharedPtr& node, std::shared_ptr<mrs_uav_hw_api::CommonHandlers_t> common_handlers) = 0;
+  virtual void initialize(const rclcpp::Node::SharedPtr &node, std::shared_ptr<mrs_uav_hw_api::CommonHandlers_t> common_handlers) = 0;
 
   virtual void destroy() = 0;
 
@@ -162,7 +162,7 @@ public:
    *
    * @return tuple(succes, message)
    */
-  virtual std::tuple<bool, std::string> callbackArming(const bool& request) = 0;
+  virtual std::tuple<bool, std::string> callbackArming(const bool &request) = 0;
 
   /**
    * @brief Callback for a service call for switching the flight controller to the "offboard" mode. When in offboard mode, the flight controller is using the
@@ -178,6 +178,6 @@ public:
   virtual ~MrsUavHwApi() = default;
 };
 
-}  // namespace mrs_uav_hw_api
+} // namespace mrs_uav_hw_api
 
 #endif

--- a/launch/hw_api.launch.py
+++ b/launch/hw_api.launch.py
@@ -93,6 +93,9 @@ def generate_launch_description():
                     {'configs': configs},
                     {'custom_config': custom_config},
                 ],
+                remappings=[
+                    ('~/errors', 'errors'),
+                ],
             )
 
         ],

--- a/src/hw_api_manager.cpp
+++ b/src/hw_api_manager.cpp
@@ -11,6 +11,7 @@
 #include <mrs_lib/publisher_handler.h>
 #include <mrs_lib/timer_handler.h>
 #include <mrs_lib/service_server_handler.h>
+#include <mrs_lib/errorgraph/error_publisher.h>
 
 #include <mrs_uav_hw_api/api.h>
 #include <mrs_uav_hw_api/publishers.h>
@@ -99,6 +100,17 @@ private:
   std::string _body_frame_name_;
   std::string _world_frame_name_;
   std::string _topic_prefix_;
+
+  // | ---------------------- errorgraph --------------------- |
+
+  enum class error_type_t : uint16_t
+  {
+    version_mismatch,
+    parameter_loading,
+    not_connected,
+  };
+
+  std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
 
   // | ---------------------- param loader ---------------------- |
 
@@ -233,6 +245,8 @@ void HwApiManager::initialize() {
 
   rclcpp::on_shutdown([this]() { this->shutdown(); });
 
+  error_publisher_ = std::make_unique<mrs_lib::errorgraph::ErrorPublisher>(node_, clock_, "HwApiManager", "main");
+
   // | ----------------------- load params ---------------------- |
 
   param_loader_ = std::make_shared<mrs_lib::ParamLoader>(node_);
@@ -250,7 +264,10 @@ void HwApiManager::initialize() {
   if (_version_ != VERSION) {
 
     RCLCPP_ERROR(node_->get_logger(), "the version of the binary (%s) does not match the config file (%s), please build me!", VERSION, _version_.c_str());
-    rclcpp::shutdown();
+    error_publisher_->addGeneralError(error_type_t::version_mismatch,
+                                      "version mismatch: binary version " + std::string(VERSION) + " != config version " + _version_);
+
+    error_publisher_->flushAndShutdown();
   }
 
   param_loader_->loadParam("hw_interface_plugin", _plugin_address_);
@@ -281,7 +298,8 @@ void HwApiManager::initialize() {
 
   if (!param_loader_->loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "could not load all parameters!");
-    rclcpp::shutdown();
+    error_publisher_->addGeneralError(error_type_t::parameter_loading, "could not load all parameters");
+    error_publisher_->flushAndShutdown();
   }
 
   // | --------------------- tf transformer --------------------- |
@@ -569,12 +587,14 @@ void HwApiManager::initialize() {
   catch (pluginlib::CreateClassException &ex1) {
     RCLCPP_ERROR(node_->get_logger(), "CreateClassException for the plugin '%s'", _plugin_address_.c_str());
     RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex1.what());
-    rclcpp::shutdown();
+    error_publisher_->addOneshotError("CreateClassException for the plugin " + _plugin_address_ + ": " + std::string(ex1.what()));
+    error_publisher_->flushAndShutdown();
   }
   catch (pluginlib::PluginlibException &ex) {
     RCLCPP_ERROR(node_->get_logger(), "PluginlibException for the plugin '%s'", _plugin_address_.c_str());
     RCLCPP_ERROR(node_->get_logger(), "Error: %s", ex.what());
-    rclcpp::shutdown();
+    error_publisher_->addOneshotError("PluginlibException for the plugin " + _plugin_address_ + ": " + std::string(ex.what()));
+    error_publisher_->flushAndShutdown();
   }
 
   // | ------------------ initialize the plugin ----------------- |
@@ -837,6 +857,10 @@ void HwApiManager::timerStatus() {
   mrs_msgs::msg::HwApiStatus status = hw_api_->getStatus();
 
   ph_status_.publish(status);
+
+  if (!status.connected) {
+    error_publisher_->addGeneralError(error_type_t::not_connected, "not connected");
+  }
 
   if (status.connected) {
 


### PR DESCRIPTION
## **BREAKING CHANGE**, depends on merge on https://github.com/ctu-mrs/mrs_lib/pull/96

**Key changes:**
- Added `ErrorPublisher` from `mrs_lib::errorgraph` to track and publish errors
- Replaced direct `rclcpp::shutdown()` calls with error publishing followed by `flushAndShutdown()`
- Added monitoring for hardware connection status with periodic error reporting


| File | Description |
| ---- | ----------- |
| src/hw_api_manager.cpp | Integrates ErrorPublisher for version mismatches, parameter loading failures, plugin exceptions, and connection status monitoring |
| launch/hw_api.launch.py | Adds topic remapping for the errors topic |
