### PR TITLE
Feat/rc rssi publishing

### DIFF
--- a/include/mrs_uav_hw_api/publishers.h
+++ b/include/mrs_uav_hw_api/publishers.h
@@ -13,6 +13,8 @@
 
 #include <mrs_msgs/msg/hw_api_status.hpp>
 #include <mrs_msgs/msg/hw_api_rc_channels.hpp>
+
+#include <std_msgs/msg/u_int8.hpp>
 #include <mrs_msgs/msg/rtk_gps.hpp>
 #include <mrs_msgs/msg/rtk_fix_type.hpp>
 #include <mrs_msgs/msg/gps_info.hpp>
@@ -38,6 +40,7 @@ typedef std::function<void(const mrs_msgs::msg::Float64Stamped &msg)>         pu
 typedef std::function<void(const sensor_msgs::msg::MagneticField &msg)>       publishMagneticField_t;
 typedef std::function<void(const mrs_msgs::msg::HwApiStatus &msg)>            publishStatus_t;
 typedef std::function<void(const mrs_msgs::msg::HwApiRcChannels &msg)>        publishRcChannels_t;
+typedef std::function<void(const std_msgs::msg::UInt8 &msg)>                  publishRcRssi_t;
 typedef std::function<void(const sensor_msgs::msg::BatteryState &msg)>        publishBatteryState_t;
 typedef std::function<void(const sensor_msgs::msg::Imu &msg)>                 publishIMU_t;
 typedef std::function<void(const sensor_msgs::msg::Range &msg)>               publishDistanceSensor_t;
@@ -104,6 +107,11 @@ struct Publishers_t
    * @brief Publisher for the RC Channels received by the flight controller.
    */
   publishRcChannels_t publishRcChannels;
+
+  /**
+   * @brief Publisher for the RC RSSI (Received Signal Strength Indicator) value (0-100).
+   */
+  publishRcRssi_t publishRcRssi;
 
   /**
    * @brief Publisher for the UAV battery state.

--- a/include/mrs_uav_hw_api/publishers.h
+++ b/include/mrs_uav_hw_api/publishers.h
@@ -13,8 +13,8 @@
 
 #include <mrs_msgs/msg/hw_api_status.hpp>
 #include <mrs_msgs/msg/hw_api_rc_channels.hpp>
+#include <mrs_msgs/msg/hw_api_rc_rssi.hpp>
 
-#include <std_msgs/msg/u_int8.hpp>
 #include <mrs_msgs/msg/rtk_gps.hpp>
 #include <mrs_msgs/msg/rtk_fix_type.hpp>
 #include <mrs_msgs/msg/gps_info.hpp>
@@ -40,7 +40,7 @@ typedef std::function<void(const mrs_msgs::msg::Float64Stamped &msg)>         pu
 typedef std::function<void(const sensor_msgs::msg::MagneticField &msg)>       publishMagneticField_t;
 typedef std::function<void(const mrs_msgs::msg::HwApiStatus &msg)>            publishStatus_t;
 typedef std::function<void(const mrs_msgs::msg::HwApiRcChannels &msg)>        publishRcChannels_t;
-typedef std::function<void(const std_msgs::msg::UInt8 &msg)>                  publishRcRssi_t;
+typedef std::function<void(const mrs_msgs::msg::HwApiRcRssi &msg)>            publishRcRssi_t;
 typedef std::function<void(const sensor_msgs::msg::BatteryState &msg)>        publishBatteryState_t;
 typedef std::function<void(const sensor_msgs::msg::Imu &msg)>                 publishIMU_t;
 typedef std::function<void(const sensor_msgs::msg::Range &msg)>               publishDistanceSensor_t;

--- a/src/hw_api_manager.cpp
+++ b/src/hw_api_manager.cpp
@@ -172,7 +172,7 @@ private:
   mrs_lib::PublisherHandler<mrs_msgs::msg::Float64Stamped>   ph_mag_heading_;
   mrs_lib::PublisherHandler<sensor_msgs::msg::MagneticField> ph_mag_magnetic_field_;
   mrs_lib::PublisherHandler<mrs_msgs::msg::HwApiRcChannels>  ph_rc_channels_;
-  mrs_lib::PublisherHandler<std_msgs::msg::UInt8>            ph_rc_rssi_;
+  mrs_lib::PublisherHandler<mrs_msgs::msg::HwApiRcRssi>      ph_rc_rssi_;
   mrs_lib::PublisherHandler<sensor_msgs::msg::BatteryState>  ph_battery_state_;
 
   mrs_lib::PublisherHandler<geometry_msgs::msg::PointStamped>      ph_position_;
@@ -198,7 +198,7 @@ private:
   void publishMagneticField(const sensor_msgs::msg::MagneticField &msg);
   void publishStatus(const mrs_msgs::msg::HwApiStatus &msg);
   void publishRcChannels(const mrs_msgs::msg::HwApiRcChannels &msg);
-  void publishRcRssi(const std_msgs::msg::UInt8 &msg);
+  void publishRcRssi(const mrs_msgs::msg::HwApiRcRssi&msg);
   void publishOrientation(const geometry_msgs::msg::QuaternionStamped &msg);
   void publishPosition(const geometry_msgs::msg::PointStamped &msg);
   void publishVelocity(const geometry_msgs::msg::Vector3Stamped &msg);
@@ -463,7 +463,7 @@ void HwApiManager::initialize() {
     opts.node          = node_;
     opts.throttle_rate = _pub_rc_channels_rate_;
 
-    ph_rc_rssi_ = mrs_lib::PublisherHandler<std_msgs::msg::UInt8>(opts, "~/rc_rssi");
+    ph_rc_rssi_ = mrs_lib::PublisherHandler<mrs_msgs::msg::HwApiRcRssi>(opts, "~/rc_rssi");
   }
 
   {
@@ -1064,7 +1064,7 @@ void HwApiManager::publishRcChannels(const mrs_msgs::msg::HwApiRcChannels &msg) 
 
 /* publishRcRssi() //{ */
 
-void HwApiManager::publishRcRssi(const std_msgs::msg::UInt8 &msg) {
+void HwApiManager::publishRcRssi(const mrs_msgs::msg::HwApiRcRssi&msg) {
 
   if (!is_initialized_) {
     return;

--- a/src/hw_api_manager.cpp
+++ b/src/hw_api_manager.cpp
@@ -198,7 +198,7 @@ private:
   void publishMagneticField(const sensor_msgs::msg::MagneticField &msg);
   void publishStatus(const mrs_msgs::msg::HwApiStatus &msg);
   void publishRcChannels(const mrs_msgs::msg::HwApiRcChannels &msg);
-  void publishRcRssi(const mrs_msgs::msg::HwApiRcRssi&msg);
+  void publishRcRssi(const mrs_msgs::msg::HwApiRcRssi &msg);
   void publishOrientation(const geometry_msgs::msg::QuaternionStamped &msg);
   void publishPosition(const geometry_msgs::msg::PointStamped &msg);
   void publishVelocity(const geometry_msgs::msg::Vector3Stamped &msg);
@@ -1064,7 +1064,7 @@ void HwApiManager::publishRcChannels(const mrs_msgs::msg::HwApiRcChannels &msg) 
 
 /* publishRcRssi() //{ */
 
-void HwApiManager::publishRcRssi(const mrs_msgs::msg::HwApiRcRssi&msg) {
+void HwApiManager::publishRcRssi(const mrs_msgs::msg::HwApiRcRssi &msg) {
 
   if (!is_initialized_) {
     return;

--- a/src/hw_api_manager.cpp
+++ b/src/hw_api_manager.cpp
@@ -27,6 +27,7 @@
 
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/empty.hpp>
+#include <std_msgs/msg/u_int8.hpp>
 #include <mrs_msgs/msg/float64_stamped.hpp>
 
 #include <pluginlib/class_loader.hpp>
@@ -171,6 +172,7 @@ private:
   mrs_lib::PublisherHandler<mrs_msgs::msg::Float64Stamped>   ph_mag_heading_;
   mrs_lib::PublisherHandler<sensor_msgs::msg::MagneticField> ph_mag_magnetic_field_;
   mrs_lib::PublisherHandler<mrs_msgs::msg::HwApiRcChannels>  ph_rc_channels_;
+  mrs_lib::PublisherHandler<std_msgs::msg::UInt8>            ph_rc_rssi_;
   mrs_lib::PublisherHandler<sensor_msgs::msg::BatteryState>  ph_battery_state_;
 
   mrs_lib::PublisherHandler<geometry_msgs::msg::PointStamped>      ph_position_;
@@ -196,6 +198,7 @@ private:
   void publishMagneticField(const sensor_msgs::msg::MagneticField &msg);
   void publishStatus(const mrs_msgs::msg::HwApiStatus &msg);
   void publishRcChannels(const mrs_msgs::msg::HwApiRcChannels &msg);
+  void publishRcRssi(const std_msgs::msg::UInt8 &msg);
   void publishOrientation(const geometry_msgs::msg::QuaternionStamped &msg);
   void publishPosition(const geometry_msgs::msg::PointStamped &msg);
   void publishVelocity(const geometry_msgs::msg::Vector3Stamped &msg);
@@ -458,6 +461,15 @@ void HwApiManager::initialize() {
     mrs_lib::PublisherHandlerOptions opts;
 
     opts.node          = node_;
+    opts.throttle_rate = _pub_rc_channels_rate_;
+
+    ph_rc_rssi_ = mrs_lib::PublisherHandler<std_msgs::msg::UInt8>(opts, "~/rc_rssi");
+  }
+
+  {
+    mrs_lib::PublisherHandlerOptions opts;
+
+    opts.node          = node_;
     opts.throttle_rate = _pub_battery_state_rate_;
 
     ph_battery_state_ = mrs_lib::PublisherHandler<sensor_msgs::msg::BatteryState>(opts, "~/battery_state");
@@ -567,6 +579,7 @@ void HwApiManager::initialize() {
   common_handlers_->publishers.publishMagneticField       = std::bind(&HwApiManager::publishMagneticField, this, std::placeholders::_1);
   common_handlers_->publishers.publishStatus              = std::bind(&HwApiManager::publishStatus, this, std::placeholders::_1);
   common_handlers_->publishers.publishRcChannels          = std::bind(&HwApiManager::publishRcChannels, this, std::placeholders::_1);
+  common_handlers_->publishers.publishRcRssi              = std::bind(&HwApiManager::publishRcRssi, this, std::placeholders::_1);
   common_handlers_->publishers.publishBatteryState        = std::bind(&HwApiManager::publishBatteryState, this, std::placeholders::_1);
 
   common_handlers_->publishers.publishPosition        = std::bind(&HwApiManager::publishPosition, this, std::placeholders::_1);
@@ -1045,6 +1058,19 @@ void HwApiManager::publishRcChannels(const mrs_msgs::msg::HwApiRcChannels &msg) 
   }
 
   ph_rc_channels_.publish(msg);
+}
+
+//}
+
+/* publishRcRssi() //{ */
+
+void HwApiManager::publishRcRssi(const std_msgs::msg::UInt8 &msg) {
+
+  if (!is_initialized_) {
+    return;
+  }
+
+  ph_rc_rssi_.publish(msg);
 }
 
 //}


### PR DESCRIPTION
## Summary
- **What changed**:
    - Adding `HwApiRCRssi` publisher
- **Why**:
    - Currently, `HwApi` only shares the **RC Channels**,  and not using the  **RC Received Signal Strength Indicator (RSSI)**  that PX4 already shares in the `rc` [message](https://github.com/mavlink/mavros/blob/master/mavros_msgs/msg/RCIn.msg#L4)

## Impact
- **Affected areas**: Added publisher 
- **Breaking changes**: Not breaking for plugins,  existing plugins keep working, they just won't publish RSSI,  but depends on https://github.com/ctu-mrs/mrs_msgs/pull/23

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [x] Tested on real HW